### PR TITLE
RFC: fix in preparation for JuliaLang/julia#37573

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PairwiseListMatrices"
 uuid = "f9da4da7-9382-5435-b973-175f5d8dfb32"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/pairwiselistmatrix.jl
+++ b/src/pairwiselistmatrix.jl
@@ -527,7 +527,7 @@ end
                               bc::Base.Broadcast.Broadcasted{Nothing}) where {T, D, VT}
     axes(dest) == axes(bc) || Base.Broadcast.throwdm(axes(dest), axes(bc))
     bc_ = Base.Broadcast.preprocess(dest, bc)
-    @iterateupper dest true list[k] = :($bc_)[CartesianIndex(i,j)] # slow: bc_ has a plm
+    @iterateupper dest true list[k] = bc_[CartesianIndex(i,j)] # slow: bc_ has a plm
     return dest
 end
 
@@ -1037,10 +1037,10 @@ function to_table(plm::PairwiseListMatrix; diagonal::Bool = true, labels = getla
     table = Array{Any}(undef, diagonal ? div(N*(N+1),2) : div(N*(N-1),2), 3)
     t = 0
     @iterateupper plm diagonal begin
-        :($t) += 1
-        :($table)[:($t), 1] = :($labels)[i]
-        :($table)[:($t), 2] = :($labels)[j]
-        :($table)[:($t), 3] = list[k]
+        t += 1
+        table[t, 1] = labels[i]
+        table[t, 2] = labels[j]
+        table[t, 3] = list[k]
     end
     table
 end
@@ -1093,10 +1093,10 @@ function to_dict(plm::PairwiseListMatrix{T,D,TV};
     K = Array{T}(undef, L)
     t = 0
     @iterateupper plm diagonal begin
-        :($t) += 1
-        :($I)[:($t)] = :($labels)[i]
-        :($J)[:($t)] = :($labels)[j]
-        :($K)[:($t)] = list[k]
+        t += 1
+        I[t] = labels[i]
+        J[t] = labels[j]
+        K[t] = list[k]
     end
     Dict(:i => I, :j => J, :values => K)
 end
@@ -1214,7 +1214,7 @@ function DelimitedFiles.writedlm(filename::String,
                        delim::Char = '\t',
                        labels::Vector{String} = getlabels(plm)) where {T,D,TV}
     open(filename, "w") do fh
-        @iterateupper plm diagonal println(:($fh), :($labels)[i], :($delim), :($labels)[j], :($delim), list[k])
+        @iterateupper plm diagonal println(fh, labels[i], delim, labels[j], delim, list[k])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -512,20 +512,20 @@ end
     full_t   = Matrix(PLMtrue)
     full_f   = Matrix(PLMfalse)
 
-    @iteratelist PLMtrue  Main.@test(list[k] == :($list_values)[k])
-    @iteratelist PLMfalse Main.@test(list[k] == :($list_values)[k])
+    @iteratelist PLMtrue  Main.@test(list[k] == list_values[k])
+    @iteratelist PLMfalse Main.@test(list[k] == list_values[k])
 
     @iteratediag PLMtrue  Main.@test(false)
     @iteratediag PLMfalse Main.@test(diag[k] == 0)
 
-    @iterateupper PLMtrue  true  list[k] = :($list_values)[k]
-    @iterateupper PLMfalse false list[k] = :($list_values)[k]
+    @iterateupper PLMtrue  true  list[k] = list_values[k]
+    @iterateupper PLMfalse false list[k] = list_values[k]
 
-    @iterateupper PLMtrue  true  list[k] = :($full_t)[i,j]
-    @iterateupper PLMtrue  false list[k] = :($full_t)[i,j]
+    @iterateupper PLMtrue  true  list[k] = full_t[i,j]
+    @iterateupper PLMtrue  false list[k] = full_t[i,j]
 
-    @iterateupper PLMtrue  true  list[k] = :($full_f)[i,j]
-    @iterateupper PLMfalse false list[k] = :($full_f)[i,j]
+    @iterateupper PLMtrue  true  list[k] = full_f[i,j]
+    @iterateupper PLMfalse false list[k] = full_f[i,j]
 end
 
 @testset "IO" begin


### PR DESCRIPTION
`:($x)` escaping `x` is basically a Julia bug, but it is made use of
extensively throughout this package. To fix this properly, this ended up
being quite a bit of refactoring, but it shouldn't be breaking because
`:($x)` is still a valid way to write `x`.